### PR TITLE
Fix logout process

### DIFF
--- a/session/i3-gnome
+++ b/session/i3-gnome
@@ -5,4 +5,8 @@ test -n "$DESKTOP_AUTOSTART_ID" && {
     dbus-send --print-reply --session --dest=org.gnome.SessionManager "/org/gnome/SessionManager" org.gnome.SessionManager.RegisterClient "string:i3-gnome" "string:$DESKTOP_AUTOSTART_ID"
 }
 
-exec i3
+i3
+
+test -n "$DESKTOP_AUTOSTART_ID" && {
+dbus-send --print-reply --session --dest=org.gnome.SessionManager "/org/gnome/SessionManager" org.gnome.SessionManager.Logout "uint32:1"
+}


### PR DESCRIPTION
This PR follows the [comments at AUR](https://aur.archlinux.org/packages/i3-gnome/).

I experienced the [same problem as _rcmz_](https://aur.archlinux.org/packages/i3-gnome#comment-567360): Exiting the i3 session (mod+shift+e) leaves the windows open, i3 keys don't work anymore, and I'm not taken back to GDM.

The solution [suggested by _Pinky_](https://aur.archlinux.org/packages/i3-gnome#comment-571236) works fine.
Don't know if it's good for all environments where `i3-gnome` may be applied.
